### PR TITLE
Remove explicit ranch dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,6 @@ defmodule BambooSmtp.Mixfile do
       # core
       {:bamboo, "~> 2.2.0"},
       {:gen_smtp, "~> 1.2.0"},
-      {:ranch, "2.0.0"},
 
       # dev / test
       {:credo, "~> 1.6.1", only: [:dev, :test]},


### PR DESCRIPTION
We originally added this to help address issues with older Elixir / OTP
versions, but we ended up dropping support for those so hopefully
removing this will fix the conflicts with the latest `cowboy` version
(2.9.0).